### PR TITLE
Added VS2022 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,7 @@ on the official Visual Studio extension gallery.
   - [x] Sorts the list for easy manageability.
   - [x] Removes duplicates, using the latest version for each duplicate redirect found.
   - [x] Makes a backup of your original file (just in case).
+
+## 1.2
+
+- [x] Works in Visual Studio 2019 AND Visual Studio 2022.

--- a/src/CloudNimble.BindingRedirectDoctor/CloudNimble.BindingRedirectDoctor.csproj
+++ b/src/CloudNimble.BindingRedirectDoctor/CloudNimble.BindingRedirectDoctor.csproj
@@ -86,10 +86,10 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.9.31025.194" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CloudNimble.BindingRedirectDoctor/source.extension.vsixmanifest
+++ b/src/CloudNimble.BindingRedirectDoctor/source.extension.vsixmanifest
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-	<Metadata>
-		<Identity Id="3d111d8d-7d15-4c6e-8ca3-494426e539ff" Version="1.1.0" Language="en-US" Publisher="Robert McLaws" />
-		<DisplayName>BindingRedirects Doctor 2022</DisplayName>
-		<Description xml:space="preserve">Cleans and sorts the Assembly Binding Redirects in your projects to make them more manageable.</Description>
-		<License>Resources\LICENSE</License>
-		<Icon>Resources\Icon.png</Icon>
-		<PreviewImage>Resources\Preview.png</PreviewImage>
-		<Tags>web.config, assembly binding redirects, binding redirects, assembly binding</Tags>
-	</Metadata>
-	<Installation>
-		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)">
-			<ProductArchitecture>amd64</ProductArchitecture>
-		</InstallationTarget>
-		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)">
-			<ProductArchitecture>x86</ProductArchitecture>
-		</InstallationTarget>
-	</Installation>
-	<Dependencies>
-		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-	</Dependencies>
-	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-	</Prerequisites>
-	<Assets>
-		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-	</Assets>
+    <Metadata>
+        <Identity Id="3d111d8d-7d15-4c6e-8ca3-494426e539ff" Version="1.2.0" Language="en-US" Publisher="Robert McLaws" />
+        <DisplayName>BindingRedirects Doctor 2019/2022</DisplayName>
+        <Description xml:space="preserve">Cleans and sorts the Assembly Binding Redirects in your projects to make them more manageable.</Description>
+        <License>Resources\LICENSE</License>
+        <Icon>Resources\Icon.png</Icon>
+        <PreviewImage>Resources\Preview.png</PreviewImage>
+        <Tags>web.config, assembly binding redirects, binding redirects, assembly binding</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>

--- a/src/CloudNimble.BindingRedirectDoctor/source.extension.vsixmanifest
+++ b/src/CloudNimble.BindingRedirectDoctor/source.extension.vsixmanifest
@@ -1,24 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="3d111d8d-7d15-4c6e-8ca3-494426e539ff" Version="1.1.0" Language="en-US" Publisher="Robert McLaws" />
-        <DisplayName>BindingRedirects Doctor 2019</DisplayName>
-        <Description xml:space="preserve">Cleans and sorts the Assembly Binding Redirects in your projects to make them more manageable.</Description>
-        <License>Resources\LICENSE</License>
-        <Icon>Resources\Icon.png</Icon>
-        <PreviewImage>Resources\Preview.png</PreviewImage>
-        <Tags>web.config, assembly binding redirects, binding redirects, assembly binding</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+	<Metadata>
+		<Identity Id="3d111d8d-7d15-4c6e-8ca3-494426e539ff" Version="1.1.0" Language="en-US" Publisher="Robert McLaws" />
+		<DisplayName>BindingRedirects Doctor 2022</DisplayName>
+		<Description xml:space="preserve">Cleans and sorts the Assembly Binding Redirects in your projects to make them more manageable.</Description>
+		<License>Resources\LICENSE</License>
+		<Icon>Resources\Icon.png</Icon>
+		<PreviewImage>Resources\Preview.png</PreviewImage>
+		<Tags>web.config, assembly binding redirects, binding redirects, assembly binding</Tags>
+	</Metadata>
+	<Installation>
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)">
+			<ProductArchitecture>x86</ProductArchitecture>
+		</InstallationTarget>
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+	</Dependencies>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+	</Assets>
 </PackageManifest>


### PR DESCRIPTION
I updated the vsix file to target VS2022 as well as 2019. I've tested with my copy of 2022 and a fresh install of 2019 and all seems to be working okay and I've been using it for the past month without issue.